### PR TITLE
new version GVI package + spacing 25 m

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -102,8 +102,8 @@
       "RemoteUsername": "hansvancalster",
       "RemoteRepo": "GVI",
       "RemoteRef": "visibility-from-sf",
-      "RemoteSha": "e63b121da46fd7941911d5b207349e276540ede9",
-      "Hash": "52e2d8690ab93997c539a1dcffd2ff8f",
+      "RemoteSha": "58e2fded65552f863da1490da923a557ba25ad6f",
+      "Hash": "a5dab940e7a729994377b319b293cf40",
       "Requirements": [
         "Rcpp",
         "RcppProgress",

--- a/src/markdown/mas/visibility.Rmd
+++ b/src/markdown/mas/visibility.Rmd
@@ -432,7 +432,7 @@ vvi_ol_25 %>%
 steekproefkader <- tar_read(steekproefkader_finaal, store = targets_store)
 ```
 
-Berekening op volledige steekproefkader (Moeren en Leemstreek) zou ongeveer `r round(nrow(steekproefkader) / nrow(ol_25mpoly) * ol_time["elapsed"] /3600, 1)` uur duren bij resolutie van 5 m en spacing van 25 m en batch size van `nrow(ol_25mpoly)`. Een wat kleinere batch size is waarschijnlijk sneller.
+Berekening op volledige steekproefkader (Moeren en Leemstreek) zou ongeveer `r round(nrow(steekproefkader) / nrow(ol_25mpoly) * ol_time["elapsed"] /3600, 1)` uur duren bij resolutie van 5 m en spacing van 25 m en batch size van `r nrow(ol_25mpoly)`. Een wat kleinere batch size is waarschijnlijk sneller.
 
 ## Wanneer is zichtbaarheid te laag?
 

--- a/src/markdown/mas/visibility.Rmd
+++ b/src/markdown/mas/visibility.Rmd
@@ -182,6 +182,33 @@ ggplot() +
   labs(title = paste("Cumulatieve VVI = ", round(cvvi_res5sp10, 2)))
 ```
 
+### Spacing 25 m, raster resolutie 5 m
+
+
+```{r}
+vvi_res5sp25 <- steekproef %>%
+  filter(pointid == "Ol_4269.12") %>%
+  bereken_vvi(output_type = "VVI", resolution = 5, spacing = 25)
+
+cvvi_res5sp25 <- steekproef %>%
+  filter(pointid == "Ol_4269.12") %>%
+  bereken_vvi(output_type = "cumulative", resolution = 5, spacing = 25)
+
+sviewshed_res5sp25 <- steekproef %>%
+  filter(pointid == "Ol_4269.12") %>%
+  bereken_vvi(output_type = "viewshed", resolution = 5, spacing = 25)
+
+
+ggplot() +
+  tidyterra::geom_spatraster(data = sviewshed_res5sp25) +
+  geom_sf(data = cirkel_300m, alpha = 0, colour = "lightblue") +
+  geom_sf(data = cirkel_25m, alpha = 0, colour = "lightblue") +
+  geom_sf(data = vvi_res5sp25, aes(colour =  VVI)) +
+  tidyterra::scale_fill_terrain_c() +
+  labs(title = paste("Cumulatieve VVI = ", round(cvvi_res5sp25, 2)))
+```
+
+
 
 ## Test op groter aantal punten
 
@@ -271,9 +298,10 @@ ol_25mpoly <- steekproef %>%
 ```
 
 ```{r vvi-dm}
+start <- proc.time()
 vvi_dm <- vvi_from_sf(
     observer = dm_25mpoly,
-    spacing = 10,
+    spacing = 25,
     cores = 1,
     progress = TRUE,
     max_distance = 300,
@@ -283,12 +311,15 @@ vvi_dm <- vvi_from_sf(
     raster_res = 5,
     output_type = "cumulative",
     by_row = TRUE)
+stop <- proc.time()
+stop - start
 ```
 
 ```{r vvi-ol}
+start <- proc.time()
 vvi_ol <- vvi_from_sf(
     observer = ol_25mpoly,
-    spacing = 10,
+    spacing = 25,
     cores = 1,
     progress = TRUE,
     max_distance = 300,
@@ -298,14 +329,15 @@ vvi_ol <- vvi_from_sf(
     raster_res = 5,
     output_type = "cumulative",
     by_row = TRUE)
-
+stop <- proc.time()
+stop - start
 ```
 
 
 ```{r}
 vvi_dm_viewshed <- vvi_from_sf(
     observer = dm_25mpoly,
-    spacing = 10,
+    spacing = 25,
     cores = 1,
     progress = TRUE,
     max_distance = 300,
@@ -371,7 +403,7 @@ vvi_ol %>%
 steekproefkader <- tar_read(steekproefkader_finaal, store = targets_store)
 ```
 
-Berekening op volledige steekproefkader (Moeren en Leemstreek) zou minimaal `r round(nrow(steekproefkader) * 25 * 5 * 1e-3 /3600, 1)` uur duren bij resolutie van 5 m en spacing van 10 m.
+Berekening op volledige steekproefkader (Moeren en Leemstreek) zou minimaal `r round(nrow(steekproefkader) * 4 * 5 * 1e-3 /3600, 1)` uur duren bij resolutie van 5 m en spacing van 25 m.
 
 ## Wanneer is zichtbaarheid te laag?
 

--- a/src/markdown/mas/visibility.Rmd
+++ b/src/markdown/mas/visibility.Rmd
@@ -330,7 +330,8 @@ vvi_ol <- vvi_from_sf(
     output_type = "cumulative",
     by_row = TRUE)
 stop <- proc.time()
-stop - start
+ol_time <- stop - start
+ol_time
 ```
 
 
@@ -403,7 +404,7 @@ vvi_ol %>%
 steekproefkader <- tar_read(steekproefkader_finaal, store = targets_store)
 ```
 
-Berekening op volledige steekproefkader (Moeren en Leemstreek) zou minimaal `r round(nrow(steekproefkader) * 4 * 5 * 1e-3 /3600, 1)` uur duren bij resolutie van 5 m en spacing van 25 m.
+Berekening op volledige steekproefkader (Moeren en Leemstreek) zou ongeveer `r round(nrow(steekproefkader) / nrow(ol_25mpoly) * ol_time["elapsed"] /3600, 1)` uur duren bij resolutie van 5 m en spacing van 25 m en batch size van `nrow(ol_25mpoly)`. Een wat kleinere batch size is waarschijnlijk sneller.
 
 ## Wanneer is zichtbaarheid te laag?
 

--- a/src/markdown/mas/visibility.Rmd
+++ b/src/markdown/mas/visibility.Rmd
@@ -315,9 +315,9 @@ stop <- proc.time()
 stop - start
 ```
 
-```{r vvi-ol}
+```{r vvi-ol-25}
 start <- proc.time()
-vvi_ol <- vvi_from_sf(
+vvi_ol_25 <- vvi_from_sf(
     observer = ol_25mpoly,
     spacing = 25,
     cores = 1,
@@ -334,6 +334,24 @@ ol_time <- stop - start
 ol_time
 ```
 
+```{r vvi-ol-10}
+start <- proc.time()
+vvi_ol_10 <- vvi_from_sf(
+    observer = ol_25mpoly,
+    spacing = 10,
+    cores = 1,
+    progress = TRUE,
+    max_distance = 300,
+    dsm_rast = dsm_ol,
+    dtm_rast = dtm_ol,
+    observer_height = 1.7,
+    raster_res = 5,
+    output_type = "cumulative",
+    by_row = TRUE)
+stop <- proc.time()
+ol_time_10 <- stop - start
+ol_time_10
+```
 
 ```{r}
 vvi_dm_viewshed <- vvi_from_sf(
@@ -378,12 +396,22 @@ dm_25mpoly %>%
 
 ```{r}
 ol_25mpoly %>%
-  bind_cols(vvi_ol) %>%
+  bind_cols(vvi_ol_25 %>% rename(cvvi_25 = cvvi)) %>%
+  bind_cols(vvi_ol_10 %>% rename(cvvi_10 = cvvi)) %>%
   ggplot() +
   geom_sf(data = ol) +
   geom_sf(aes(fill = cvvi, colour = cvvi))
 ```
 
+```{r}
+ol_25mpoly %>%
+  bind_cols(vvi_ol_25 %>% rename(cvvi_25 = cvvi)) %>%
+  bind_cols(vvi_ol_10 %>% rename(cvvi_10 = cvvi)) %>%
+  ggplot() +
+  geom_point(aes(x = cvvi_25, y = cvvi_10)) +
+  geom_abline() +
+  labs(x = "cvvi 25m spacing", y = "cvvi 10m spacing")
+```
 
 ```{r}
 vvi_dm %>%
@@ -392,7 +420,7 @@ vvi_dm %>%
 ```
 
 ```{r}
-vvi_ol %>%
+vvi_ol_25 %>%
   bind_cols(ol_25mpoly) %>%
   ggplot() + 
   geom_density(aes(x = cvvi, fill = openheid_klasse), alpha = 0.2)
@@ -425,7 +453,7 @@ En in de Oostelijke leemstreek:
 
 ```{r}
 ol_25mpoly %>%
-  bind_cols(vvi_ol) %>%
+  bind_cols(vvi_ol_25) %>%
   ungroup() %>%
   mutate(pointid = reorder(pointid, cvvi, mean)) %>%
   ggplot() +


### PR DESCRIPTION
The speedup here is not very huge, but should be enough to allow cumulative visibility for 100K points if we make some changes to the targets pipeline: 

- setting `spacing = 25` (which corresponds to 4 points inside the 25 m radius circle)
- use batching to calculate the target via https://docs.ropensci.org/tarchetypes/reference/tar_group_size.html - I suggest to try `size = 200`. I think this will also allow you to stop the target pipeline and inspect intermediate results (and `tar_meta()` for timings), after which calculation can resume from where it was stopped (skipping already calculated batches).