### PR TITLE
allow renv::restore to install from source

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,1 +1,6 @@
 source("renv/activate.R")
+local({
+  options(
+    pkgType = "both"
+  )
+})


### PR DESCRIPTION
Dit zou problemen met renv::restore() wanneer er geen binaries available zijn moeten oplossen. Het overruled de instelling in onze Rprofile.site.